### PR TITLE
Fix NPM publish 404 error with trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,6 +45,10 @@ jobs:
           fi
           echo "Detected version: $VERSION -> tag: $(cat $GITHUB_OUTPUT | grep tag= | cut -d= -f2)"
 
+      # Upgrade npm to latest version to support trusted publishing with scoped packages
+      # See: https://github.com/npm/cli/issues/8678
+      - run: npm install -g npm@latest
+
       - run: npm install
 
       # Modify package.json, inserting version attribute


### PR DESCRIPTION
Add npm upgrade step to fix known bug with older npm versions that don't properly support OIDC trusted publishing for scoped packages.

GitHub Actions runners have outdated npm versions that fail when publishing scoped packages with provenance. Upgrading to npm@latest (11.5.1+) resolves the 404 error during token exchange.

Fixes: https://github.com/npm/cli/issues/8678