### PR TITLE
Add ConsistentRead parameter support to FakeDynamoDBInterface

### DIFF
--- a/packages/dynamodb-entity-store-testutils/src/fakeDynamoDBInterface.ts
+++ b/packages/dynamodb-entity-store-testutils/src/fakeDynamoDBInterface.ts
@@ -36,7 +36,7 @@ const supportedParamKeysByFunction = {
     'ExpressionAttributeNames',
     'ExpressionAttributeValues'
   ],
-  get: ['TableName', 'Key'],
+  get: ['TableName', 'Key', 'ConsistentRead'],
   delete: ['TableName', 'Key'],
   batchWrite: ['RequestItems'],
   transactionWrite: ['TransactItems'],
@@ -46,16 +46,18 @@ const supportedParamKeysByFunction = {
     'ExpressionAttributeNames',
     'ExpressionAttributeValues',
     'Limit',
-    'ExclusiveStartKey'
+    'ExclusiveStartKey',
+    'ConsistentRead'
   ],
   queryAllPages: [
     'TableName',
     'KeyConditionExpression',
     'ExpressionAttributeNames',
-    'ExpressionAttributeValues'
+    'ExpressionAttributeValues',
+    'ConsistentRead'
   ],
-  scanOnePage: ['TableName'],
-  scanAllPages: ['TableName']
+  scanOnePage: ['TableName', 'ConsistentRead'],
+  scanAllPages: ['TableName', 'ConsistentRead']
 }
 
 function checkSupportedParams(


### PR DESCRIPTION
Updated FakeDynamoDBInterface to accept (but ignore) the ConsistentRead parameter